### PR TITLE
Fix auto_detect_operators bug

### DIFF
--- a/scripts/auto_detect_operators.py
+++ b/scripts/auto_detect_operators.py
@@ -212,11 +212,13 @@ def expandParameters(params, model, level=0):
   return new_params
 
 def getRelevantParametersPropCorr(process, possible_params, model):
-  dummy_particles = ["h1", "z1", "w1", "t1"]
+  dummy_particles = ["h1", "z1", "w1+", "w1-", "t1", "t1~"]
   dummy_to_parameter = {"h1": "dWH",
                         "z1": "dWZ",
-                        "w1": "dWW",
-                        "t1": "dWT"}
+                        "w1+": "dWW",
+                        "w1-": "dWW",
+                        "t1": "dWT",
+                        "t1~":"dWT"}
   dependent_parameters = []
  
   ps_files = getPSFiles(process)


### PR DESCRIPTION
If a W boson or top quark is in a diagram, then the corresponding dummy particles for the propagator corrections will be w1+ w1- and t1 t1~ respectively. This is slightly different from the Z boson and Higgs which are h1 and z1 respectively since they are their own antiparticle. 

Previously, the script was only searching for w1 and t1, not w1+ w1- t1 and t1~. So it would have missed W boson propagator corrections and maybe top quark corrections. This has now been fixed.