### PR TITLE
get_scaling.py prints the coeff values by default

### DIFF
--- a/scripts/eftscaling.py
+++ b/scripts/eftscaling.py
@@ -328,7 +328,7 @@ class EFT2ObsHist(object):
         for ib in range(self.nbins()):
             print('Bin %-4i numEntries: %-10i mean: %-10.3g stderr: %-10.3g' % (ib, self.numEntries[0][ib], vals[0][ib], uncerts[0][ib]))
             extra_label = ''
-            if self.bin_labels is not None:
+            if len(self.bin_labels) > 0:
                 extra_label += ', label=%s' % self.bin_labels[ib]
             print('         edges: %s%s' % (self.bin_edges[ib], extra_label))
             print('-' * n_divider)

--- a/scripts/get_scaling.py
+++ b/scripts/get_scaling.py
@@ -130,6 +130,7 @@ e2ohist = EFT2ObsHist(
     bin_edges=edges,
     bin_labels=bin_labels)
 
+e2ohist.printToScreen()
 e2oscaling = EFTScaling.fromEFT2ObsHist(e2ohist)
 
 if args.save_raw:


### PR DESCRIPTION
This restores the old behaviour, which prints a nicely formatted table of the coeffs in each bin, and the associated stat error