### PR TITLE
Extra options for make_gridpack.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,14 @@ Once complete the gridpack `gridpack_zh-HEL.tar.gz` will be copied to the main d
 
 An addtional file, `rw_module_zh-HEL.tar.gz` is also produced. See the section below on standalone reweighting for more information. Note that standalone reweighting with NLO matrix elements is not currently possible.
 
+The full set of options supported by the `make_gridpack.sh` script are:
+
+```sh
+./scripts/make_gridpack.sh [card dir] [make standalone=0/1] [no. cores] [postfit] [extra param/run card settings ...]
+```
+
+Set `no. cores` to 2 or more to use multiple CPU cores in parallel. The `postfix` setting adds an optional extra label to the output: `gridpack_[process][postfix].tar.gz`. All remaining arguments are interpreted as commands that should be passed to Madgraph to modify the param or run cards. For example, `""set htjmin 800"`.
+
 ### Event generation step
 
 Now everything is set up we can proceed to the event generation.

--- a/scripts/make_gridpack.sh
+++ b/scripts/make_gridpack.sh
@@ -33,8 +33,6 @@ pushd ${MG_DIR}/${PROCESS}
   echo "reweight=OFF"
   echo "done"
   echo "set gridpack True"
-  echo "set use_syst False"
-  echo "set systematics_program None"
   for i in "${SETTERS[@]}"; do echo ${i}; done
   echo "done"
 } > mgrunscript

--- a/scripts/make_gridpack.sh
+++ b/scripts/make_gridpack.sh
@@ -12,6 +12,9 @@ PROCESS=$(basename $1)
 CARDDIR=$1
 EXPORTRW=${2-0}
 CORES=${3-0}
+POSTFIX=${4-""}
+ALLARGS=("$@")
+SETTERS=( "${ALLARGS[@]:4}" )
 IWD=${PWD}
 
 ### SET ENVIRONMENT VARIABLES HERE
@@ -24,11 +27,15 @@ cp cards/${CARDDIR}/pythia8_card.dat ${MG_DIR}/${PROCESS}/Cards/pythia8_card_def
 
 pushd ${MG_DIR}/${PROCESS}
 # Create MG config
+
 {
   echo "shower=OFF"
   echo "reweight=OFF"
   echo "done"
   echo "set gridpack True"
+  echo "set use_syst False"
+  echo "set systematics_program None"
+  for i in "${SETTERS[@]}"; do echo ${i}; done
   echo "done"
 } > mgrunscript
 
@@ -78,9 +85,9 @@ pushd "gridpack_${PROCESS}"
 popd
 
 rm -r "gridpack_${PROCESS}"
-cp "gridpack_${PROCESS}.tar.gz" "${IWD}/gridpack_${PROCESS}.tar.gz"
+cp "gridpack_${PROCESS}.tar.gz" "${IWD}/gridpack_${PROCESS}${POSTFIX}.tar.gz"
+rm "gridpack_${PROCESS}.tar.gz"
 
-# cp "${RUNLABEL}_gridpack.tar.gz" "${IWD}/gridpack_${PROCESS}.tar.gz"
 popd
 
-echo ">> Gridpack ${IWD}/gridpack_${PROCESS}.tar.gz has been successfully created"
+echo ">> Gridpack ${IWD}/gridpack_${PROCESS}${POSTFIX}.tar.gz has been successfully created"

--- a/scripts/setup_process_standalone.sh
+++ b/scripts/setup_process_standalone.sh
@@ -11,13 +11,13 @@ fi
 PROCESS=$1
 
 pushd "${MG_DIR}"
-if [ -d "${PROCESS}-standalone" ]; then
+if [ -d "${PROCESS##*/}-standalone" ]; then
 	echo "Process directory already exists, remove this first to run setup"
 	exit 1
 fi
 
-cat "../cards/${PROCESS}/proc_card.dat" | sed "s/^output .*/output standalone ${PROCESS}-standalone --prefix=int/" | ./bin/mg5_aMC
-	pushd "${PROCESS}-standalone/SubProcesses"
+cat "../cards/${PROCESS}/proc_card.dat" | sed "s/^output .*/output standalone ${PROCESS##*/}-standalone --prefix=int/" | ./bin/mg5_aMC
+	pushd "${PROCESS##*/}-standalone/SubProcesses"
 		make allmatrix2py.so
 	popd
 popd
@@ -26,7 +26,7 @@ if [ -f "cards/${PROCESS}/run_card.dat" ]; then
 	echo ">> File cards/${PROCESS}/run_card.dat already exists, it will not be modified"
 else
 	echo ">> File cards/${PROCESS}/run_card.dat does not exist, copying from ${MG_DIR}/${PROCESS}/Cards/run_card.dat"
-	cp "${MG_DIR}/${PROCESS}/Cards/run_card.dat" "cards/${PROCESS}/run_card.dat"
+	cp "${MG_DIR}/${PROCESS}/Cards/run_card.dat" "cards/${PROCESS##*/}/run_card.dat"
 fi
 
 if [ -f "cards/${PROCESS}/pythia8_card.dat" ]; then


### PR DESCRIPTION
Add extra optional arguments to make_gridpack.sh:

 - `prefix` - to add an extra string to the output gridpack name
 - `madgraph settings` - commands to pass through to madgraph - allows modifying the param or run card on the fly

In addition, we will now set `use_syst` and `systematics_program` to false automatically, which we need to do for the weight transformation to work correctly (in future we might make this more flexible)