### PR TITLE
Improvements for get_scaling.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ In this final step we first merge the yoda output files:
 yodamerge -o test-zh/Rivet.yoda test-zh/Rivet_*
 ```
 
-and then use the script `get_scaling.py` to extract the A_j and B_jk coefficents and their statistical uncertainties:
+and then use the script `get_scaling.py` to extract the A_j and B_jk coefficients and their statistical uncertainties:
 
 ```sh
 python scripts/get_scaling.py -c config_HEL_STXS.json [--nlo] \
@@ -289,6 +289,9 @@ where the options are
  - `--save [json,txt,tex]` a comma separated list of the output formats to save in
  - `--translate-tex` a json dictionary file that converts the parameter names to latex format - only needed when `tex` is chosen in `--save`
  - `--rebin` optionally re-bin the histogram first by providing a list of the new bin edges
+ - `--filter-params` a comma separated list of a subset of the parameters to keep (all others will be dropped)
+ - `--print-style` either "perBin" or "perTerm", which specifies the format for printing to the screen
+ - `--color-above` when using --print-style perTerm, highlight relative uncertainties above this threshold in red
 
 The terms calculated for each bin are printed to the screen, e.g.
 

--- a/scripts/get_scaling.py
+++ b/scripts/get_scaling.py
@@ -21,6 +21,9 @@ parser.add_argument('--translate-tex', default=None, help="json file to translat
 parser.add_argument('--translate-txt', default=None, help="json file to translate parameter names in the text file")
 parser.add_argument('--bin-labels', default=None, help="json file to translate bin labels")
 parser.add_argument('--nlo', action='store_true', help="Set if weights came from NLO reweighting")
+parser.add_argument('--filter-params', default=None, help="Specify a subset of parameters to include")
+parser.add_argument('--print-style', default="perBin", choices=["perBin", "perTerm"], help="Specify the format for printing to the screen")
+parser.add_argument('--color-above', default=None, type=float, help="When using --print-style perTerm, highlight relative uncertainties above this threshold")
 args = parser.parse_args()
 
 
@@ -57,7 +60,11 @@ hname = args.hist
 aos = yoda.read(args.input, asdict=True)
 
 n_pars = len(pars)
-n_hists = 1 + n_pars * 2 + (n_pars * n_pars - n_pars) / 2
+n_hists = int(1 + n_pars * 2 + (n_pars * n_pars - n_pars) / 2)
+
+filter = list()
+if args.filter_params is not None:
+    filter = args.filter_params.split(',')
 
 hists = []
 for i in range(n_hists):
@@ -130,8 +137,8 @@ e2ohist = EFT2ObsHist(
     bin_edges=edges,
     bin_labels=bin_labels)
 
-e2ohist.printToScreen()
-e2oscaling = EFTScaling.fromEFT2ObsHist(e2ohist)
+e2ohist.printToScreen(style=args.print_style, colorAbove=args.color_above)
+e2oscaling = EFTScaling.fromEFT2ObsHist(e2ohist, filter=filter)
 
 if args.save_raw:
     print('>> Saving EFT2ObsHist as %s_raw.json' % args.output)


### PR DESCRIPTION
 - Add option `--filter-params`, takes a comma separated list of a subset of parameters to keep in the parameterisation. I.e. useful if you want to drop some parameters.
 - Adds `--print-style`, default to current behaviour "perBin", for printing to screen. Adds --print-style perTerm which organises the bin values for each term in columns instead of rows, and also adds option `--color-above [val]` for highlighting entries that have a relative uncertainty above the threshold (see example below)

![image](https://github.com/ajgilbert/EFT2Obs/assets/1001931/c9f6be82-9c82-4aca-89cb-989024d11557)
