### PR TITLE
MG5_aMC_v2_9_16: fix download path

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -5,7 +5,7 @@ export PYTHONPATH="${PWD}/$(echo lhapdf/lib64/python*/site-packages):${PYTHONPAT
 export LD_LIBRARY_PATH="${PWD}/lhapdf/lib:${LD_LIBRARY_PATH}"
 export RIVET_ANALYSIS_PATH=${PWD}/RivetPlugins
 export MG_DIR="MG5_aMC_v2_9_16"
-export MG_TARBALL="MG5aMC_LTS_v2.9.16.tar.gz"
+export MG_TARBALL="MG5_aMC_v2.9.16.tar.gz"
 export RIVET_VERSION="3.1.3"
 export DEBUG_SCRIPTS=0
 

--- a/scripts/setup_mg5.sh
+++ b/scripts/setup_mg5.sh
@@ -29,7 +29,7 @@ if [ -d "${MG_DIR}" ]; then
   echo "Directory ${MG_DIR} already exists, remove this first to re-install"
   exit 1
 fi
-wget "https://launchpad.net/mg5amcnlo/3.0/3.5.x/+download/${MG_TARBALL}"
+wget "https://launchpad.net/mg5amcnlo/lts/2.9.x/+download/${MG_TARBALL}"
 tar -zxf "${MG_TARBALL}"
 rm "${MG_TARBALL}"
 


### PR DESCRIPTION
download link is now `https://launchpad.net/mg5amcnlo/lts/2.9.x/+download/MG5_aMC_v2.9.16.tar.gz`